### PR TITLE
Improve text handling

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -428,12 +428,16 @@ class Zui {
 						cursorX--;
 					}
 				}
-				else if (key == kha.input.KeyCode.Return) { // Deselect
-					deselectText(); // One-line text for now
+				else if (key == kha.input.KeyCode.CapsLock) {
+					// dummy check to prevent previous character from being entered accidentally
+					// terrible hack... should improve
 				}
-				else if (char != "") {
-					text = text.substr(0, cursorX) + char + text.substr(cursorX);
-					cursorX++;
+				else if (char != null) {
+					if ((char != "") && char.charCodeAt(0) >= 32 || char.charCodeAt(0) < 127 || char.charCodeAt(0) >= 128)
+					{
+						text = text.substr(0, cursorX) + char + text.substr(cursorX);
+						cursorX++;
+					}
 				}
 			}
 

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -428,6 +428,8 @@ class Zui {
 						cursorX--;
 					}
 				}
+				else if (key == kha.input.KeyCode.Return) { // Deselect
+ -					deselectText(); // One-line text for now
 				else if (key == kha.input.KeyCode.CapsLock) {
 					// dummy check to prevent previous character from being entered accidentally
 					// terrible hack... should improve

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -429,7 +429,8 @@ class Zui {
 					}
 				}
 				else if (key == kha.input.KeyCode.Return) { // Deselect
- -					deselectText(); // One-line text for now
+ 					deselectText(); // One-line text for now
+				}
 				else if (key == kha.input.KeyCode.CapsLock) {
 					// dummy check to prevent previous character from being entered accidentally
 					// terrible hack... should improve


### PR DESCRIPTION
This should significantly improve the behaviour of the text input element. Only letters, numbers, and symbols should be entered now, and any null values ignored instead of being entered. Because I use Caps Lock a lot, I've also added that as a dummy check to prevent the previous character from being entered - there is probably a better way to handle this, but I can't think of one.