### PR TITLE
expose onKeyDown, onKeyUp, onKeyPress

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -913,14 +913,14 @@ class Zui {
 		this.inputY = inputY;
 	}
 
-	function onKeyDown(code: kha.input.KeyCode) {
+	public function onKeyDown(code: kha.input.KeyCode) {
 		isKeyDown = true;
 		this.key = code;
 	}
 
-	function onKeyUp(code: kha.input.KeyCode) {}
+	public function onKeyUp(code: kha.input.KeyCode) {}
 
-	function onKeyPress(char: String) {
+	public function onKeyPress(char: String) {
 		isKeyDown = true;
 		this.char = char;
 	}


### PR DESCRIPTION
They are public now so they can be used when you initialize zui with ```{ autoNotifyInput: false }```
