### PR TITLE
comment out unused hover variable (silences vscode's problem page)

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -460,7 +460,7 @@ class Zui {
 	public function panel(handle: Handle, text: String, accent = 0, isTree = false): Bool {
 		if (!isVisible(ELEMENT_H())) { endElement(); return handle.selected; }
 		if (getReleased()) handle.selected = !handle.selected;
-		var hover = getHover();
+		// var hover = getHover();
 
 		if (accent > 0) { // Bg
 			g.color = t.PANEL_BG_COL;


### PR DESCRIPTION
Seems to only pop up in vscode + kha extensions, but not KodeStudio.

![image](https://user-images.githubusercontent.com/13007175/42217861-15a7b026-7ec7-11e8-97bc-c3b4146c28ac.png)
