### PR TITLE
use Map<Int, Handle> instead of Array<Handle> for Handle.children

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -1428,7 +1428,7 @@ class Handle {
 	public var dragX = 0;
 	public var dragY = 0;
 	public var changed = false;
-	var children: Array<Handle>;
+	var children: Map<Int, Handle>;
 
 	public function new(ops: HandleOptions = null) {
 		if (ops != null) {
@@ -1443,9 +1443,11 @@ class Handle {
 
 	public function nest(i: Int, ops: HandleOptions = null): Handle {
 		if (children == null) children = [];
-		while (children.length <= i) children.push(null);
-		if (children[i] == null) children[i] = new Handle(ops);
-		return children[i];
+		var c = children.get(i);
+		if (c == null) {
+			children.set(i, c = new Handle(ops));
+		}
+		return c;
 	}
 
 	public static var global = new Handle();


### PR DESCRIPTION
This change makes it possible to use arbitrary Id's (hashes and the like) instead of only array indices. This is useful when you display items that can be sorted (or change their order dynamically via logic code in your app) and keep their handle properties in sync (say a corresponding panel should stay open).

This might affect performance, but i haven't noticed anything worth mentioning in our app so far.
