### PR TITLE
use a custom shader for text rendering

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -76,6 +76,7 @@ class Zui {
 
 	public var g: Graphics; // Drawing
 	var globalG: Graphics;
+	var rtTextPipeline: kha.graphics4.PipelineState; // rendering text into rendertargets
 
 	var t: zui.Themes.TTheme;
 	var SCALE: Float;
@@ -162,6 +163,10 @@ class Zui {
 				if ((isCopy || isPaste) && ++copyFrame > 1) { isCopy = isCut = isPaste = false; copyFrame = 0; }
 			});
 		}
+		var rtTextVS = kha.graphics4.Graphics2.createTextVertexStructure();
+		rtTextPipeline = kha.graphics4.Graphics2.createTextPipeline(rtTextVS);
+		rtTextPipeline.alphaBlendSource = BlendOne;
+		rtTextPipeline.compile();
 	}
 
 	public function setScale(factor: Float) {
@@ -1186,7 +1191,9 @@ class Zui {
 		else if (align == Right) xOffset = _w - ops.font.width(fontSize, text) - TEXT_OFFSET();
 
 		if (!enabled) fadeColor();
+		g.pipeline = rtTextPipeline;
 		g.drawString(text, _x + xOffset, _y + fontOffsetY + yOffset);
+		g.pipeline = null;
 	}
 
 	function endElement(elementSize: Null<Float> = null) {


### PR DESCRIPTION
Here is a screenshot of 2 screenshots to showcase the problem :innocent: 

![Screenshot_2019-07-12_08-50-41](https://user-images.githubusercontent.com/13007175/61108976-064f2800-a484-11e9-949a-7043fc57dce0.png)

Notice how the red/orange background bleeds into the word `FLUSH 6 / 7` in the upper image. With this PR that won't happen anymore, as visible in the bottom image. This is especially noticeable if you have draggable windows.

We had a small conversation in kha irc about it as well:

```

4.7.2019 23:47 | dave: | i have some  alpha weirdness when i'm rendering a font to a rendertarget and then  that rendertarget to the screen. is it me being stupid, or is there  something broken in kha (happens in a normal debug html5 build as well,  not only in kodegarden)?  http://kodegarden.org/#be01da52bdab9fe8f62cb0a6b17436023837831b
4.7.2019 23:50 | Kyric: | probably would help if you didn't have high contrast checker patterns to mess with your eye
4.7.2019 23:51 | Robert: | The font shader still  doesn't use premultiplied alpha which makes things not work together  quite perfectly. I should maybe change that.
4.7.2019 23:53 | Robert: | Oh, but that's not what you mean right? You're just talking about the font becoming a little transparent?
4.7.2019 23:53 | dave: | the checker pattern is  there to actually showcase that behavior. it doesn't mess with your  eyes. take a screenshot an you see it's actually a bit transparent
4.7.2019 23:53 | dave: | yes exactly
4.7.2019 23:54 | dave: | like it's overwriting the alpha values
4.7.2019 23:55 | Robert: | Yes and that's actually  correct, that way you can draw a font to a texture and it still looks  nice... unless you first draw a background of course.
4.7.2019 23:55 | Robert: | Try to use a RGBX render target. Do we have that?
4.7.2019 23:55 | dave: | uhm, but it draws the blue background first?
4.7.2019 23:57 | Robert: | Yes, that gets ignored. Alpha being overwritten is normal, it's rare to use target alpha for anything.
4.7.2019 23:59 | Robert: | But we do use separate blending so you can change the alpha blend modes in createTextPipeline.
5.7.2019 00:00 | Robert: | I remember we set them to the same as the color modes because something which I can not remember.
5.7.2019 00:00 | Robert: | Also there used to be a time before computers supported separate blending.
5.7.2019 00:02 | dave: | ah yeah, when i change the alphaBlendSource to BlendOne it works
5.7.2019 00:06 | Robert: | But oh no, flash doesn't support that.
5.7.2019 00:08 | Robert: | Maybe the something was just that I wanted to have the same behaviour on all targets by default
```

@RobDangerous Hm, re-reading that conversation, maybe that should be changed in kha, or at least mention it somewhere in the docs i guess?