### PR TITLE
Custom theme support for canvas

### DIFF
--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -6,7 +6,8 @@ using kha.graphics2.GraphicsExtension;
 class Canvas {
 
 	public static var assetMap = new Map<Int, Dynamic>(); // kha.Image | kha.Font
-	static var events: Array<String> = [];
+	public static var themes = new Array<zui.Themes.TTheme>();
+	static var events:Array<String> = [];
 
 	public static var screenW = -1;
 	public static var screenH = -1;
@@ -86,7 +87,7 @@ class Canvas {
 			var fontAsset = element.asset != null && StringTools.endsWith(element.asset, ".ttf");
 			if (fontAsset) ui.ops.font = getAsset(canvas, element.asset);
 			ui.fontSize = scaled(element.height);
-			ui.t.TEXT_COL = element.color_text;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
 			ui.text(getText(canvas, element), element.alignment);
 
 			ui.ops.font = font;
@@ -96,10 +97,10 @@ class Canvas {
 		case Button:
 			var bh = ui.t.BUTTON_H;
 			ui.t.BUTTON_H = scaled(element.height);
-			ui.t.BUTTON_COL = element.color;
-			ui.t.BUTTON_TEXT_COL = element.color_text;
-			ui.t.BUTTON_HOVER_COL = element.color_hover;
-			ui.t.BUTTON_PRESSED_COL = element.color_press;
+			ui.t.BUTTON_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.BUTTON_TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).BUTTON_TEXT_COL);
+			ui.t.BUTTON_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
+			ui.t.BUTTON_PRESSED_COL = getColor(element.color_press, getTheme(canvas.theme).BUTTON_PRESSED_COL);
 			if (ui.button(getText(canvas, element), element.alignment)) {
 				var e = element.event;
 				if (e != null && e != "") events.push(e);
@@ -121,90 +122,90 @@ class Canvas {
 
 		case FRectangle:
 			var col = ui.g.color;
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.fillRect(ui._x, ui._y, ui._w, scaled(element.height));
 			ui.g.color = col;
 
 		case FCircle:
 			var col = ui.g.color;
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.fillCircle(ui._x + (scaled(element.width) / 2), ui._y + (scaled(element.height) / 2), ui._w / 2);
 			ui.g.color = col;
 
 		case Rectangle:
 			var col = ui.g.color;
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.drawRect(ui._x, ui._y, ui._w, scaled(element.height), element.strength);
 			ui.g.color = col;
 
 		case Circle:
 			var col = ui.g.color;
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.drawCircle(ui._x+(scaled(element.width) / 2), ui._y + (scaled(element.height) / 2), ui._w / 2, element.strength);
 			ui.g.color = col;
 
 		case FTriangle:
 			var col = ui.g.color;
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.fillTriangle(ui._x + (ui._w / 2), ui._y, ui._x, ui._y + scaled(element.height), ui._x + ui._w, ui._y + scaled(element.height));
 			ui.g.color = col;
 
 		case Triangle:
 			var col = ui.g.color;
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.drawLine(ui._x + (ui._w / 2), ui._y, ui._x, ui._y + scaled(element.height), element.strength);
 			ui.g.drawLine(ui._x, ui._y + scaled(element.height), ui._x + ui._w, ui._y + scaled(element.height), element.strength);
 			ui.g.drawLine(ui._x + ui._w, ui._y + scaled(element.height), ui._x + (ui._w / 2), ui._y, element.strength);
 			ui.g.color = col;
 
 		case Check:
-			ui.t.TEXT_COL = element.color_text;
-			ui.t.ACCENT_COL = element.color;
-			ui.t.ACCENT_HOVER_COL = element.color_hover;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
 			ui.check(h.nest(element.id), getText(canvas, element));
 
 		case Radio:
-			ui.t.TEXT_COL = element.color_text;
-			ui.t.ACCENT_COL = element.color;
-			ui.t.ACCENT_HOVER_COL = element.color_hover;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
 			Ext.inlineRadio(ui, h.nest(element.id), getText(canvas, element).split(";"));
 
 		case Combo:
-			ui.t.TEXT_COL = element.color_text;
-			ui.t.LABEL_COL = element.color_text;
-			ui.t.ACCENT_COL = element.color;
-			ui.t.SEPARATOR_COL = element.color;
-			ui.t.ACCENT_HOVER_COL = element.color_hover;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.LABEL_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.SEPARATOR_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
 			ui.combo(h.nest(element.id), getText(canvas, element).split(";"));
 
 		case Slider:
-			ui.t.TEXT_COL = element.color_text;
-			ui.t.LABEL_COL = element.color_text;
-			ui.t.ACCENT_COL = element.color;
-			ui.t.ACCENT_HOVER_COL = element.color_hover;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.LABEL_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
 			ui.slider(h.nest(element.id), getText(canvas, element), 0.0, 1.0, true, 100, true, element.alignment);
 
 		case TextInput:
-			ui.t.TEXT_COL = element.color_text;
-			ui.t.LABEL_COL = element.color_text;
-			ui.t.ACCENT_COL = element.color;
-			ui.t.ACCENT_HOVER_COL = element.color_hover;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.LABEL_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
 			ui.textInput(h.nest(element.id), getText(canvas, element), element.alignment);
 
 		case KeyInput:
-			ui.t.TEXT_COL = element.color_text;
-			ui.t.LABEL_COL = element.color_text;
-			ui.t.ACCENT_COL = element.color;
-			ui.t.ACCENT_HOVER_COL = element.color_hover;
+			ui.t.TEXT_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.LABEL_COL = getColor(element.color_text, getTheme(canvas.theme).TEXT_COL);
+			ui.t.ACCENT_COL = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
+			ui.t.ACCENT_HOVER_COL = getColor(element.color_hover, getTheme(canvas.theme).BUTTON_HOVER_COL);
 			Ext.keyInput(ui, h.nest(element.id), getText(canvas, element));
 
 		case ProgressBar:
 			var col = ui.g.color;
 			var progress = element.progress_at;
 			var totalprogress = element.progress_total;
-			ui.g.color = element.color_progress;
+			ui.g.color = getColor(element.color_progress, getTheme(canvas.theme).TEXT_COL);
 			ui.g.fillRect(ui._x, ui._y, ui._w / totalprogress * Math.min(progress, totalprogress), scaled(element.height));
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.drawRect(ui._x, ui._y, ui._w, scaled(element.height), element.strength);
 			ui.g.color = col;
 
@@ -212,9 +213,9 @@ class Canvas {
 			var col = ui.g.color;
 			var progress = element.progress_at;
 			var totalprogress = element.progress_total;
-			ui.g.color = element.color_progress;
+			ui.g.color = getColor(element.color_progress, getTheme(canvas.theme).TEXT_COL);
 			ui.g.drawArc(ui._x + (scaled(element.width) / 2), ui._y + (scaled(element.height) / 2), ui._w / 2, -Math.PI / 2, ((Math.PI * 2) / totalprogress * progress) - Math.PI / 2, element.strength);
-			ui.g.color = element.color;
+			ui.g.color = getColor(element.color, getTheme(canvas.theme).BUTTON_COL);
 			ui.g.fillCircle(ui._x + (scaled(element.width) / 2), ui._y + (scaled(element.height) / 2), (ui._w / 2) - 10);
 			ui.g.color = col;
 		case Empty:
@@ -256,6 +257,18 @@ class Canvas {
 	}
 
 	static inline function scaled(f: Float): Int { return Std.int(f * _ui.SCALE()); }
+
+	public static inline function getColor(color: Null<Int>, defaultColor: Int): Int {
+		return color != null ? color : defaultColor;
+	}
+
+	public static function getTheme(theme: String): zui.Themes.TTheme {
+		for (t in Canvas.themes) {
+			if (t.NAME == theme) return t;
+		}
+
+		return null;
+	}
 }
 
 typedef TCanvas = {
@@ -265,6 +278,7 @@ typedef TCanvas = {
 	var width: Int;
 	var height: Int;
 	var elements: Array<TElement>;
+	var theme: String;
 	@:optional var assets: Array<TAsset>;
 	@:optional var locales: Array<TLocale>;
 }
@@ -280,6 +294,7 @@ typedef TElement = {
 	@:optional var rotation: Null<kha.FastFloat>;
 	@:optional var text: String;
 	@:optional var event: String;
+	// null = follow theme settings
 	@:optional var color: Null<Int>;
 	@:optional var color_text: Null<Int>;
 	@:optional var color_hover: Null<Int>;

--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -82,7 +82,6 @@ class Canvas {
 		case Text:
 			var font = ui.ops.font;
 			var size = ui.fontSize;
-			var tcol = ui.t.TEXT_COL;
 
 			var fontAsset = element.asset != null && StringTools.endsWith(element.asset, ".ttf");
 			if (fontAsset) ui.ops.font = getAsset(canvas, element.asset);
@@ -92,7 +91,6 @@ class Canvas {
 
 			ui.ops.font = font;
 			ui.fontSize = size;
-			ui.t.TEXT_COL = tcol;
 
 		case Button:
 			var bh = ui.t.BUTTON_H;

--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -1,6 +1,7 @@
 package zui;
 
 import zui.Zui;
+import zui.Popup;
 import kha.input.Keyboard;
 import kha.input.KeyCode;
 
@@ -140,6 +141,25 @@ class Ext {
 		if (showAdd && ui.button(addLabel)) {
 			addCb("untitled");
 		}
+	}
+
+	public static function colorField(ui: Zui, handle:Handle, alpha = false): Int {
+		ui.g.color = handle.color;
+
+		ui.drawRect(ui.g, true, ui._x + 2, ui._y, ui._w - 4, ui.BUTTON_H());
+		ui.g.color = ui.getHover() ? ui.t.ACCENT_HOVER_COL : ui.t.ACCENT_COL;
+		ui.drawRect(ui.g, false, ui._x + 2, ui._y, ui._w - 4, ui.BUTTON_H(), 1.0);
+
+		if (ui.getStarted()) {
+			Popup.showCustom(
+				new Zui(ui.ops),
+				function(ui:Zui) {
+					colorWheel(ui, handle, alpha);},
+				Std.int(ui.inputX), Std.int(ui.inputY), 200, 500);
+		}
+
+		ui.endElement();
+		return handle.color;
 	}
 
 	public static function colorPicker(ui: Zui, handle: Handle, alpha = false): Int {

--- a/Sources/zui/Popup.hx
+++ b/Sources/zui/Popup.hx
@@ -1,0 +1,124 @@
+package zui;
+
+import zui.Zui;
+import kha.System;
+
+@:access(zui.Zui)
+class Popup {
+	public static var show = false;
+
+	static var ui:Zui = null;
+	static var hwnd = new Handle();
+	static var boxTitle = "";
+	static var boxText = "";
+	static var boxCommands:Zui->Void = null;
+	static var modalX = 0;
+	static var modalY = 0;
+	static var modalW = 400;
+	static var modalH = 160;
+
+	public static function render(g:kha.graphics2.Graphics) {
+		if (boxCommands == null) {
+			ui.begin(g);
+			if (ui.window(hwnd, modalX, modalY, modalW, modalH)) {
+				drawTitle(g);
+
+				for (line in boxText.split("\n")) {
+					ui.text(line);
+				}
+
+				ui._y = ui._h - ui.t.BUTTON_H - 10;
+				ui.row([1/3, 1/3, 1/3]);
+				ui.endElement();
+				if (ui.button("OK")) {
+					show = false;
+				}
+			}
+			ui.end();
+		}
+		else {
+			ui.begin(g);
+			if (ui.window(hwnd, modalX, modalY, modalW, modalH)) {
+				drawTitle(g);
+
+				ui._y += 10;
+				boxCommands(ui);
+			}
+			ui.end();
+		}
+	}
+
+	public static function drawTitle(g:kha.graphics2.Graphics) {
+		if (boxTitle != "") {
+			g.color = ui.t.SEPARATOR_COL;
+			ui.drawRect(g, true, ui._x, ui._y, ui._w, ui.t.BUTTON_H);
+
+			g.color = ui.t.TEXT_COL;
+			ui.text(boxTitle);
+		}
+	}
+
+	public static function update() {
+		var inUse = ui.comboSelectedHandle != null;
+
+		// Close popup
+		if (ui.inputStarted && !inUse) {
+			if (ui.inputX < modalX || ui.inputX > modalX + modalW || ui.inputY < modalY || ui.inputY > modalY + modalH) {
+				show = false;
+			}
+		}
+	}
+
+	/**
+	 * Displays a message box with a title, a text body and a centered "OK" button.
+	 * @param ui    the Zui instance for the popup
+	 * @param title the title to display
+	 * @param text  the text to display
+	 */
+	public static function showMessage(ui:Zui, title:String, text:String) {
+		Popup.ui = ui;
+		init();
+
+		boxTitle = title;
+		boxText = text;
+		boxCommands = null;
+	}
+
+	/**
+	 * Displays a popup box with custom drawing code.
+	 * @param ui       the Zui instance for the popup
+	 * @param commands the function for drawing the popup's content
+	 * @param mx       the x position of the popup. -1 = screen center (defaults to -1)
+	 * @param my       the y position of the popup. -1 = screen center (defaults to -1)
+	 * @param mw       the width of the popup (defaults to 400)
+	 * @param mh       the height of the popup (defaults to 160)
+	 */
+	public static function showCustom(ui:Zui, commands:Zui->Void = null, mx = -1, my = -1, mw = 400, mh = 160) {
+		Popup.ui = ui;
+		init(mx, my, mw, mh);
+
+		boxCommands = commands;
+	}
+
+	static function init(mx = -1, my = -1, mw = 400, mh = 160) {
+		var appW = System.windowWidth();
+		var appH = System.windowHeight();
+
+		modalX = mx;
+		modalY = my;
+		modalW = Std.int(mw * ui.SCALE());
+		modalH = Std.int(mh * ui.SCALE());
+
+		// Center popup window if no value is given
+		if (mx == -1) { modalX = Std.int(appW / 2 - modalW / 2);}
+		if (my == -1) { modalY = Std.int(appH / 2 - modalH / 2);}
+
+		// Limit popup position to screen
+		modalX = Std.int(Math.max(0, Math.min(modalX, appW - modalW)));
+		modalY = Std.int(Math.max(0, Math.min(modalY, appH - modalH)));
+
+		hwnd.dragX = 0;
+		hwnd.dragY = 0;
+		show = true;
+	}
+}

--- a/Sources/zui/Popup.hx
+++ b/Sources/zui/Popup.hx
@@ -97,6 +97,8 @@ class Popup {
 		Popup.ui = ui;
 		init(mx, my, mw, mh);
 
+		boxTitle = "";
+		boxText = "";
 		boxCommands = commands;
 	}
 

--- a/Sources/zui/Themes.hx
+++ b/Sources/zui/Themes.hx
@@ -3,6 +3,8 @@ package zui;
 class Themes {
 
 	public static var dark: TTheme = {
+		NAME: "Default Dark",
+
 		FONT_SIZE: 13,
 		ELEMENT_W: 100,
 		ELEMENT_H: 24,
@@ -36,6 +38,8 @@ class Themes {
 
 	// 2x scaled, for games
 	public static var light: TTheme = {
+		NAME: "Default Light",
+
 		FONT_SIZE: 13 * 2,
 		ELEMENT_W: 100 * 2,
 		ELEMENT_H: 24 * 2,
@@ -69,6 +73,8 @@ class Themes {
 }
 
 typedef TTheme = {
+	var NAME:String;
+
 	var FONT_SIZE: Int;
 	var ELEMENT_W: Int;
 	var ELEMENT_H: Int;

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -1457,6 +1457,12 @@ class Handle {
 		return c;
 	}
 
+	public function unnest(i: Int) {
+		if (children != null) {
+			children.remove(i);
+		}
+	}
+
 	public static var global = new Handle();
 }
 


### PR DESCRIPTION
This PR adds custom theme support for canvas.

**Changed:**
- Added UI Popup widget (very similar to Armorpaint)
- Added colorField UI component (like the color selection in Blender)
- Canvases now support custom themes
- Themes have names now
- Handles can be un-nested

Linked to https://github.com/armory3d/armory2d/pull/38 and https://github.com/armory3d/armory/pull/1513.