### PR TITLE
Fix anchors

### DIFF
--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -49,30 +49,30 @@ class Canvas {
 		var ch = scaled(canvas.height);
 
 		switch (element.anchor) {
-		case Top:
-			px -= (cw - screenW) / 2;
-		case TopRight:
-			px -= cw - screenW;
-		case CenterLeft:
-			py -= (ch - screenH) / 2;
-		case Center:
-			px -= (cw - screenW) / 2;
-			py -= (ch - screenH) / 2;
-		case CenterRight:
-			px -= cw - screenW;
-			py -= (ch - screenH) / 2;
-		case BottomLeft:
-			py -= ch - screenH;
-		case Bottom:
-			px -= (cw - screenW) / 2;
-			py -= ch - screenH;
-		case BottomRight:
-			px -= cw - screenW;
-			py -= ch - screenH;
+			case Top:
+				px = cw / 2 - scaled(element.width) / 2;
+			case TopRight:
+				px = cw - scaled(element.width);
+			case CenterLeft:
+				py = ch / 2 - scaled(element.height) / 2;
+			case Center:
+				px = cw / 2 - scaled(element.width) / 2;
+				py = ch / 2 - scaled(element.height) / 2;
+			case CenterRight:
+				px = cw - scaled(element.width);
+				py = ch / 2 - scaled(element.height) / 2;
+			case BottomLeft:
+				py = ch - scaled(element.height);
+			case Bottom:
+				px = cw / 2 - scaled(element.width) / 2;
+				py = ch - scaled(element.height);
+			case BottomRight:
+				px = cw - scaled(element.width);
+				py = ch - scaled(element.height);
 		}
 
-		ui._x = canvas.x + scaled(element.x) + scaled(px);
-		ui._y = canvas.y + scaled(element.y) + scaled(py);
+		ui._x = canvas.x + scaled(element.x) + px;
+		ui._y = canvas.y + scaled(element.y) + py;
 		ui._w = scaled(element.width);
 
 		var rotated = element.rotation != null && element.rotation != 0;

--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -45,30 +45,38 @@ class Canvas {
 
 		if (element == null || element.visible == false) return;
 
-		var cw = scaled(canvas.width);
-		var ch = scaled(canvas.height);
+		var cw: Float;
+		var ch: Float;
+		if (element.parent == null) {
+			cw = scaled(canvas.width);
+			ch = scaled(canvas.height);
+		} else {
+			var parent = elemById(canvas, element.parent);
+			cw = scaled(parent.width);
+			ch = scaled(parent.height);
+		}
 
 		switch (element.anchor) {
 			case Top:
-				px = cw / 2 - scaled(element.width) / 2;
+				px += cw / 2 - scaled(element.width) / 2;
 			case TopRight:
-				px = cw - scaled(element.width);
+				px += cw - scaled(element.width);
 			case CenterLeft:
-				py = ch / 2 - scaled(element.height) / 2;
+				py += ch / 2 - scaled(element.height) / 2;
 			case Center:
-				px = cw / 2 - scaled(element.width) / 2;
-				py = ch / 2 - scaled(element.height) / 2;
+				px += cw / 2 - scaled(element.width) / 2;
+				py += ch / 2 - scaled(element.height) / 2;
 			case CenterRight:
-				px = cw - scaled(element.width);
-				py = ch / 2 - scaled(element.height) / 2;
+				px += cw - scaled(element.width);
+				py += ch / 2 - scaled(element.height) / 2;
 			case BottomLeft:
-				py = ch - scaled(element.height);
+				py += ch - scaled(element.height);
 			case Bottom:
-				px = cw / 2 - scaled(element.width) / 2;
-				py = ch - scaled(element.height);
+				px += cw / 2 - scaled(element.width) / 2;
+				py += ch - scaled(element.height);
 			case BottomRight:
-				px = cw - scaled(element.width);
-				py = ch - scaled(element.height);
+				px += cw - scaled(element.width);
+				py += ch - scaled(element.height);
 		}
 
 		ui._x = canvas.x + scaled(element.x) + px;
@@ -224,7 +232,7 @@ class Canvas {
 
 		if (element.children != null) {
 			for (id in element.children) {
-				drawElement(ui, canvas, elemById(canvas, id), element.x + px, element.y + py);
+				drawElement(ui, canvas, elemById(canvas, id), scaled(element.x) + px, scaled(element.y) + py);
 			}
 		}
 

--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -250,7 +250,7 @@ class Canvas {
 	}
 
 	/**
-	 * Returns the positional offset of the given element based on its anchor setting.
+	 * Returns the positional scaled offset of the given element based on its anchor setting.
 	 * @param canvas The canvas object
 	 * @param element The element
 	 * @return Array<Float> [xOffset, yOffset]

--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -45,39 +45,9 @@ class Canvas {
 
 		if (element == null || element.visible == false) return;
 
-		var cw: Float;
-		var ch: Float;
-		if (element.parent == null) {
-			cw = scaled(canvas.width);
-			ch = scaled(canvas.height);
-		} else {
-			var parent = elemById(canvas, element.parent);
-			cw = scaled(parent.width);
-			ch = scaled(parent.height);
-		}
-
-		switch (element.anchor) {
-			case Top:
-				px += cw / 2 - scaled(element.width) / 2;
-			case TopRight:
-				px += cw - scaled(element.width);
-			case CenterLeft:
-				py += ch / 2 - scaled(element.height) / 2;
-			case Center:
-				px += cw / 2 - scaled(element.width) / 2;
-				py += ch / 2 - scaled(element.height) / 2;
-			case CenterRight:
-				px += cw - scaled(element.width);
-				py += ch / 2 - scaled(element.height) / 2;
-			case BottomLeft:
-				py += ch - scaled(element.height);
-			case Bottom:
-				px += cw / 2 - scaled(element.width) / 2;
-				py += ch - scaled(element.height);
-			case BottomRight:
-				px += cw - scaled(element.width);
-				py += ch - scaled(element.height);
-		}
+		var anchorOffset = getAnchorOffset(canvas, element);
+		px += anchorOffset[0];
+		py += anchorOffset[1];
 
 		ui._x = canvas.x + scaled(element.x) + px;
 		ui._y = canvas.y + scaled(element.y) + py;
@@ -277,6 +247,52 @@ class Canvas {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Returns the positional offset of the given element based on its anchor setting.
+	 * @param canvas The canvas object
+	 * @param element The element
+	 * @return Array<Float> [xOffset, yOffset]
+	 */
+	public static function getAnchorOffset(canvas: TCanvas, element: TElement): Array<Float> {
+		var boxWidth, boxHeight: Float;
+		var offsetX = 0.0;
+		var offsetY = 0.0;
+
+		if (element.parent == null) {
+			boxWidth = scaled(canvas.width);
+			boxHeight = scaled(canvas.height);
+		} else {
+			var parent = elemById(canvas, element.parent);
+			boxWidth = scaled(parent.width);
+			boxHeight = scaled(parent.height);
+		}
+
+		switch (element.anchor) {
+			case Top:
+				offsetX += boxWidth / 2 - scaled(element.width) / 2;
+			case TopRight:
+				offsetX += boxWidth - scaled(element.width);
+			case CenterLeft:
+				offsetY += boxHeight / 2 - scaled(element.height) / 2;
+			case Center:
+				offsetX += boxWidth / 2 - scaled(element.width) / 2;
+				offsetY += boxHeight / 2 - scaled(element.height) / 2;
+			case CenterRight:
+				offsetX += boxWidth - scaled(element.width);
+				offsetY += boxHeight / 2 - scaled(element.height) / 2;
+			case BottomLeft:
+				offsetY += boxHeight - scaled(element.height);
+			case Bottom:
+				offsetX += boxWidth / 2 - scaled(element.width) / 2;
+				offsetY += boxHeight - scaled(element.height);
+			case BottomRight:
+				offsetX += boxWidth - scaled(element.width);
+				offsetY += boxHeight - scaled(element.height);
+		}
+
+		return [offsetX, offsetY];
 	}
 }
 


### PR DESCRIPTION
This PR fixes anchors and their behaviour with parented elements and different scale settings :) The x and y coordinates of the elements are the offset from anchor position, so if the anchor is set to "Right", a negative x value is the margin of the element to the right border.
This should fix https://github.com/armory3d/armory/issues/1492