### PR TITLE
Fix text element height for larger font sizes

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -613,7 +613,7 @@ class Zui {
 		g.color = t.TEXT_COL;
 		drawString(g, text, TEXT_OFFSET(), 0, align);
 
-		endElement();
+		endElement(Math.max(ELEMENT_H(), ops.font.height(fontSize)) + ELEMENT_OFFSET());
 		return started ? State.Started : released ? State.Released : down ? State.Down : State.Idle;
 	}
 


### PR DESCRIPTION
Used `max()` to keep compatibility with outliner in Armory2D (e.g.)

Forgot this commit when opening https://github.com/armory3d/armory2d/pull/48. Now it should look like on the screenshots