### PR TITLE
Small improvements and adjustments

### DIFF
--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -146,9 +146,9 @@ class Ext {
 	public static function colorField(ui: Zui, handle:Handle, alpha = false): Int {
 		ui.g.color = handle.color;
 
-		ui.drawRect(ui.g, true, ui._x + 2, ui._y, ui._w - 4, ui.BUTTON_H());
+		ui.drawRect(ui.g, true, ui._x + 2, ui._y + ui.buttonOffsetY, ui._w - 4, ui.BUTTON_H());
 		ui.g.color = ui.getHover() ? ui.t.ACCENT_HOVER_COL : ui.t.ACCENT_COL;
-		ui.drawRect(ui.g, false, ui._x + 2, ui._y, ui._w - 4, ui.BUTTON_H(), 1.0);
+		ui.drawRect(ui.g, false, ui._x + 2, ui._y + ui.buttonOffsetY, ui._w - 4, ui.BUTTON_H(), 1.0);
 
 		if (ui.getStarted()) {
 			Popup.showCustom(

--- a/Sources/zui/Themes.hx
+++ b/Sources/zui/Themes.hx
@@ -15,7 +15,7 @@ class Themes {
 		CHECK_SELECT_SIZE: 8,
 		SCROLL_W: 6,
 		TEXT_OFFSET: 8,
-		TAB_W: 12,
+		TAB_W: 6,
 		FILL_WINDOW_BG: false,
 		FILL_BUTTON_BG: true,
 		FILL_ACCENT_BG: false,

--- a/Sources/zui/Themes.hx
+++ b/Sources/zui/Themes.hx
@@ -34,6 +34,7 @@ class Themes {
 		SEPARATOR_COL: 0xff272727,
 		HIGHLIGHT_COL: 0xff205d9c,
 		CONTEXT_COL: 0xff222222,
+		PANEL_BG_COL: 0xff3b3b3b,
 	};
 
 	// 2x scaled, for games
@@ -69,6 +70,7 @@ class Themes {
 		SEPARATOR_COL: 0xff999999,
 		HIGHLIGHT_COL: 0xff205d9c,
 		CONTEXT_COL: 0xffaaaaaa,
+		PANEL_BG_COL: 0xffaaaaaa,
 	};
 }
 
@@ -104,4 +106,5 @@ typedef TTheme = {
 	var SEPARATOR_COL: Int;
 	var HIGHLIGHT_COL: Int;
 	var CONTEXT_COL: Int;
+	var PANEL_BG_COL: Int;
 }

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -559,11 +559,16 @@ class Zui {
 		_w = Std.int(!currentWindow.scrollEnabled ? _windowW : _windowW - SCROLL_W());
 	}
 
-	public function panel(handle: Handle, text: String, isTree = false): Bool {
+	public function panel(handle: Handle, text: String, isTree = false, filled = true, pack = true): Bool {
 		if (!isVisible(ELEMENT_H())) { endElement(); return handle.selected; }
 		if (getReleased()) {
 			handle.selected = !handle.selected;
 			handle.changed = changed = true;
+		}
+
+		if (filled) {
+			g.color = t.PANEL_BG_COL;
+			drawRect(g, true, _x, _y, _w, ELEMENT_H());
 		}
 
 		isTree ? drawTree(handle.selected) : drawArrow(handle.selected);
@@ -573,6 +578,7 @@ class Zui {
 		drawString(g, text, titleOffsetX, 0);
 
 		endElement();
+		if (pack && !handle.selected) _y -= ELEMENT_OFFSET();
 
 		return handle.selected;
 	}

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -1322,14 +1322,18 @@ class Zui {
 		_w = Std.int(getRatio(ratios[curRatio], _w));
 	}
 
-	public function indent() {
+	public function indent(bothSides = true) {
 		_x += TAB_W();
 		_w -= TAB_W();
+
+		if (bothSides) _w -= TAB_W();
 	}
 
-	public function unindent() {
+	public function unindent(bothSides = true) {
 		_x -= TAB_W();
 		_w += TAB_W();
+
+		if (bothSides) _w += TAB_W();
 	}
 
 	function fadeColor() {


### PR DESCRIPTION
- Fixed `Ext.colorField()` y position
- Prettier indentation (old behaviour still possible)
![indentation](https://user-images.githubusercontent.com/17685000/74085359-8ff5c100-4a78-11ea-9444-ca4f1687c1f4.jpg)
  (Left: old, right: new)
- Implement panel background color (see `Basic` panel in the screenshot above)
- Denser alignment of panels (like Blender's `align` parameter for layouts)