### PR TITLE
Update text area to format tabs correctly

### DIFF
--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -355,6 +355,7 @@ class Ext {
 	}
 
 	public static function textArea(ui: Zui, handle: Handle, align = Align.Left, editable = true): String {
+		handle.text = StringTools.replace(handle.text, "\t", "    ");
 		var lines = handle.text.split("\n");
 		var selected = ui.textSelectedHandle == handle; // Text being edited
 		var cursorStartX = ui.cursorX;


### PR DESCRIPTION
This change makes it so a text area correctly formats strings containing tab indentations. I made the modification in the textArea function so that it only affects the text area. Is this the right place to make the change?