### PR TITLE
Removed canvas scaling in `Canvas.getAnchorOffset`.

### DIFF
--- a/Sources/zui/Canvas.hx
+++ b/Sources/zui/Canvas.hx
@@ -265,8 +265,8 @@ class Canvas {
 		var offsetY = 0.0;
 
 		if (element.parent == null) {
-			boxWidth = scaled(canvas.width);
-			boxHeight = scaled(canvas.height);
+			boxWidth = canvas.width;
+			boxHeight = canvas.height;
 		} else {
 			var parent = elemById(canvas, element.parent);
 			boxWidth = scaled(parent.width);


### PR DESCRIPTION
Current behavior makes very difficult to correctly scale the UI
if you are also using something to automatically adjust it's dimensions
to match current window — such as Armory does.

More explanations and examples here → https://github.com/armory3d/armory/issues/1666