### PR TITLE
Make ui.image collisions limited to image width

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -664,7 +664,7 @@ class Zui {
 		var released = getReleased(h);
 		var hover = getHover(h);
 		if(curRatio == -1 && (started || down || released || hover)){
-			if(_windowX > inputX || inputX > (_windowX+ _x + image.width) ){
+			if(_windowX + _x > inputX || inputX > (_windowX+ _x + image.width) ){
 				down = started = released = hover = false;
 			}
 		}

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -663,6 +663,11 @@ class Zui {
 		var down = getPushed(h);
 		var released = getReleased(h);
 		var hover = getHover(h);
+		if(started || down || released || hover){
+			if(_windowX > inputX || inputX > (_windowX+ _x + image.width) ){
+				down = started = released = hover = false;
+			}
+		}
 		g.color = tint;
 		if (!enabled) fadeColor();
 		var h_float: Float = h; // TODO: hashlink fix

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -663,7 +663,7 @@ class Zui {
 		var down = getPushed(h);
 		var released = getReleased(h);
 		var hover = getHover(h);
-		if(started || down || released || hover){
+		if(curRatio == -1 && (started || down || released || hover)){
 			if(_windowX > inputX || inputX > (_windowX+ _x + image.width) ){
 				down = started = released = hover = false;
 			}


### PR DESCRIPTION
Right now collisions are limited to the height of the element; Zui never considers the width of an image when detecting clicks. This addresses the issue. 

Since the way Zui handles input is related to the window width and the element heigth, it may be interesting in the future to have a better way to limit the collisions of elements on the x axis i.e. by having an endElementX().

If this is something that would be desired I may look into it. 

One of the situations where the collisions are faulty is for example when we have tooltips for tabs. the tooltip will appear for the whole window instead of just on hover of the Tab.  