### PR TITLE
Middle mouse on Linux crash's zui.Nodes

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -1614,7 +1614,7 @@ class Zui {
 
 	public function onCut(): String { isCut = true; return onCopy(); }
 	public function onCopy(): String { isCopy = true; return textToCopy; }
-	public function onPaste(s: String) { isPaste = true; textToPaste = s; }
+	public function onPaste(s: String) { isPaste = isCtrlDown && key == KeyCode.V; textToPaste = s; }
 
 	public inline function ELEMENT_W(): Float { return t.ELEMENT_W * SCALE(); }
 	public inline function ELEMENT_H(): Float { return t.ELEMENT_H * SCALE(); }


### PR DESCRIPTION
This fixes middle mouse button being considered a paste event; i.e. we crash when we have zui.Nodes open and we middle mouse click to pan since it thinks we want to paste on Linux(this can vary on flavors of linux but it is a default on some flavors). 

This could crash if what we have in the pastebin isn't json and we arrive at this [line](https://github.com/armory3d/zui/blob/master/Sources/zui/Nodes.hx#L389)

Maybe some testing will be needed on other platforms since Rob says:
![image](https://user-images.githubusercontent.com/29337013/97204864-06645b80-178d-11eb-81ef-15f27ad25e63.png)
