### PR TITLE
Add keyInput for NODES buttons

### DIFF
--- a/Sources/zui/Nodes.hx
+++ b/Sources/zui/Nodes.hx
@@ -593,6 +593,15 @@ class Nodes {
 				buthandle.position = but.default_value;
 				but.default_value = ui.combo(buthandle, texts, tr(but.name));
 			}
+			else if (but.type == "KEY") {
+				ny += lineh;
+				ui._x = nx;
+				ui._y = ny;
+				ui._w = w;
+				var buthandle = nhandle.nest(buti);
+				buthandle.value = but.default_value;
+				but.default_value = Ext.keyInput(ui,buthandle,tr(but.name));
+			}
 			else if (but.type == "BOOL") {
 				ny += lineh;
 				ui._x = nx;


### PR DESCRIPTION
The issue is when we want to add keycode input right now we need to use ENUM but the enum list can be long. Since we have a specific zui component for keycode input we use this now with a dedicated type for buttons.