### PR TITLE
Reset window scroll when closing the popup

### DIFF
--- a/Sources/zui/Popup.hx
+++ b/Sources/zui/Popup.hx
@@ -5,8 +5,14 @@ import kha.System;
 
 @:access(zui.Zui)
 class Popup {
-	public static var show = false;
-
+	public static var show(default,set):Bool = false;
+	static function set_show(value:Bool){
+		if(!value){
+			hwnd.scrollOffset = 0.0;
+		}
+		return show = value;
+	}
+	
 	static var ui:Zui = null;
 	static var hwnd = new Handle();
 	static var boxTitle = "";


### PR DESCRIPTION
Right now if the popup needed to scroll down to say go to a apply or cancel button, next time we would open a popup the window would be scrolled to as far as was set beforehand. This addresses the issue by reseting the scroll offset when closing the Popup.