### PR TITLE
Disable cut and paste for readonly text input controls

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -859,7 +859,7 @@ class Zui {
 			if (!selecting && !isCtrlDown) highlightAnchor = cursorX;
 		}
 
-		if (textToPaste != "") { // Process cut copy paste
+		if (editable && textToPaste != "") { // Process cut copy paste
 			text = text.substr(0, highlightAnchor) + textToPaste + text.substr(cursorX);
 			cursorX += textToPaste.length;
 			highlightAnchor = cursorX;
@@ -869,7 +869,7 @@ class Zui {
 		if (highlightAnchor == cursorX) textToCopy = text; // Copy
 		else if (highlightAnchor < cursorX) textToCopy = text.substring(highlightAnchor, cursorX);
 		else textToCopy = text.substring(cursorX, highlightAnchor);
-		if (isCut) { // Cut
+		if (editable && isCut) { // Cut
 			if (highlightAnchor == cursorX) text = "";
 			else if (highlightAnchor < cursorX) {
 				text = text.substr(0, highlightAnchor) + text.substr(cursorX, text.length);


### PR DESCRIPTION
Currently text input controls allow for cut and paste if they are readonly. This behavior can be observed in ArmorPaint's About... dialog box. See https://github.com/armory3d/armorpaint/issues/949