### PR TITLE
Do not select last character if AltGr was pressed

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -856,7 +856,9 @@ class Zui {
 				}
 			}
 			var selecting = isShiftDown && (key == KeyCode.Left || key == KeyCode.Right || key == KeyCode.Shift);
-			if (!selecting && !isCtrlDown) highlightAnchor = cursorX;
+			// isCtrlDown && isAltDown is the condition for AltGr was pressed. 
+			// AltGr is part of the German keyboard layout and part of key combinations like AltGr + e -> €
+			if (!selecting && (!isCtrlDown || (isCtrlDown && isAltDown))) highlightAnchor = cursorX;
 		}
 
 		if (editable && textToPaste != "") { // Process cut copy paste


### PR DESCRIPTION
Fixes https://github.com/armory3d/armorpaint/issues/1073
Description:
The German keyboard layout uses AltGr as a modifier key like Shift. For example AltGr + q = @ or AltGr + e = €.
The AltGr event is represented by Ctrl + Alt. Because of 
`if (!selecting && !isCtrlDown ) highlightAnchor = cursorX;`
 in line 860 text input controls do not shift the hightlight anchor if AltGr is pressed. This yields a selection of the last character if AltGr + some other key is pressed. 
This PR extends this condition by (!isCtrlDown || (isCtrlDown && isAltDown)) to disallow ctrl pressed while allowing ctrl+alt pressed.