### PR TITLE
Improve hex code parsing

### DIFF
--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -234,7 +234,16 @@ class Ext {
 		else if (pos == 2) {
 			#if js
 			handle.text = untyped (handle.color >>> 0).toString(16);
-			handle.color = untyped parseInt(ui.textInput(handle, "#"), 16);
+			var hexCode = ui.textInput(handle, "#");
+			
+			if (hexCode.length >= 1 && hexCode.charAt(0) == "#") hexCode = hexCode.substr(1); //allow # at the beginning
+			if (hexCode.length == 3) //3 digit CSS style values like fa0 --> ffaa00
+				hexCode = hexCode.charAt(0) + hexCode.charAt(0) + hexCode.charAt(1) + hexCode.charAt(1) + hexCode.charAt(2) + hexCode.charAt(2);
+			if (hexCode.length == 4) //4 digit CSS style values 
+				hexCode = hexCode.charAt(0) + hexCode.charAt(0) + hexCode.charAt(1) + hexCode.charAt(1) + hexCode.charAt(2) + hexCode.charAt(2) + hexCode.charAt(3) + hexCode.charAt(3);
+			if (hexCode.length == 6) hexCode = "ff" + hexCode; //make the alpha channel optional
+			
+			handle.color = untyped parseInt(hexCode, 16);
 			#end
 		}
 		if (h0.changed || h1.changed || h2.changed) handle.changed = ui.changed = true;


### PR DESCRIPTION
This PR makes hex codes much more usable in ArmorPaint.
Currently ArmorPaint enforces a 8-digit representation for hex colors, where the first two digits are the alpha value. Most hex codes out there are not in this format but have a "CSS-style". The PR introduces the following formats and conversions
1. ff83ff (rrggbb) --> ffff83ff
2. abc (rgb with the meaning rrggbb) --> ffaabbcc
3. c123 (argb with the meaning aarrggbb) --> cc112233
4. An optional # at the front, i.e. #00ff00 --> ff00ff00