### PR TITLE
Avoid copying empty node selection

### DIFF
--- a/Sources/zui/Nodes.hx
+++ b/Sources/zui/Nodes.hx
@@ -469,12 +469,14 @@ class Nodes {
 					copyLinks.push(l);
 				}
 			}
-			var copyCanvas: TNodeCanvas = {
-				name: canvas.name,
-				nodes: copyNodes,
-				links: copyLinks
-			};
-			clipboard = haxe.Json.stringify(copyCanvas);
+			if (copyNodes.length > 0) {
+				var copyCanvas: TNodeCanvas = {
+					name: canvas.name,
+					nodes: copyNodes,
+					links: copyLinks
+				};
+				clipboard = haxe.Json.stringify(copyCanvas);
+			}
 			cutSelected = Zui.isCut;
 		}
 		if (Zui.isPaste && !ui.isTyping) {


### PR DESCRIPTION
In case the user selects an output material node or only other nodes that are internally excluded the copy command yields a empty list of nodes to copy. The json representation of this empty list with its links and so on is not the empty string. The code in ArmorPaint that checks whether there is something to paste or not has the condition `uiMenu.enabled = Nodes.clipboard != "";` I.e. if the user does only copy excluded nodes the paste command is enabled even though there is nothing to paste. This PR changes the behavior such that in this case simply nothing is copied and the old clipboard content is preserved, i.e. it behaves like the user did not try to copy anything.