### PR TITLE
Add colorwheel preview to rgbapopup

### DIFF
--- a/Sources/zui/Nodes.hx
+++ b/Sources/zui/Nodes.hx
@@ -797,9 +797,9 @@ class Nodes {
 	}
 
 	public function rgbaPopup(ui: Zui, nhandle: zui.Zui.Handle, val: kha.arrays.Float32Array, x: Int, y: Int) {
-		popup(x, y, Std.int(140 * scaleFactor), Std.int(ui.t.ELEMENT_H * 9), function(ui: Zui) {
+		popup(x, y, Std.int(140 * scaleFactor), Std.int(ui.t.ELEMENT_H * 10), function(ui: Zui) {
 			nhandle.color = kha.Color.fromFloats(val[0], val[1], val[2]);
-			Ext.colorWheel(ui, nhandle, false, null, false);
+			Ext.colorWheel(ui, nhandle, false, null, true);
 			val[0] = nhandle.color.R; val[1] = nhandle.color.G; val[2] = nhandle.color.B;
 		});
 	}


### PR DESCRIPTION
Imho it is better to be consistent between the RGB node and the Material Output node in ArmorPaint. Therefore I enabled the color wheel preview for the rgbapopup
Fixes parts of https://github.com/armory3d/armorpaint/issues/1106