### PR TITLE
Add value slider for color picker

### DIFF
--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -146,6 +146,7 @@ class Ext {
 	}
 
 	static var wheelSelectedHande: Handle = null;
+	static var gradientSelectedHandle: Handle = null;
 	public static function colorWheel(ui: Zui, handle: Handle, alpha = false, w: Null<Float> = null, h: Null<Float> = null, colorPreview = true): kha.Color {
 		if (w == null) w = ui._w;
 		rgbToHsv(handle.color.R, handle.color.G, handle.color.B, ar);
@@ -170,6 +171,10 @@ class Ext {
 		var cwh = cw / 2;
 		var cx = ox;
 		var cy = oy + csat * cwh; // Sat is distance from center
+		var gradTx = px + 0.897*w ;
+		var gradTy = oy - cwh;
+		var gradW = 0.0777*w;
+		var gradH = cw;
 		// Rotate around origin by hue
 		var theta = chue * (Math.PI * 2.0);
 		var cx2 = Math.cos(theta) * (cx - ox) - Math.sin(theta) * (cy - oy) + ox;
@@ -177,17 +182,26 @@ class Ext {
 		cx = cx2;
 		cy = cy2;
 
+		ui._x = px - (scroll ? 0 : ui.SCROLL_W() / 2);
+		ui._y = py;
+		ui.image(ui.ops.black_white_gradient);
+
 		ui.g.color = 0xff000000;
 		ui.g.fillRect(cx - 3 * ui.SCALE(), cy - 3 * ui.SCALE(), 6 * ui.SCALE(), 6 * ui.SCALE());
 		ui.g.color = 0xffffffff;
 		ui.g.fillRect(cx - 2 * ui.SCALE(), cy - 2 * ui.SCALE(), 4 * ui.SCALE(), 4 * ui.SCALE());
+
+		ui.g.color = 0xff000000;
+		ui.g.fillRect(gradTx + gradW/2 - 3 * ui.SCALE(), gradTy + (1-cval)*gradH - 3 * ui.SCALE(), 6 * ui.SCALE(), 6 * ui.SCALE());
+		ui.g.color = 0xffffffff;
+		ui.g.fillRect(gradTx + gradW/2 - 2 * ui.SCALE(), gradTy + (1-cval)*gradH - 2 * ui.SCALE(), 4 * ui.SCALE(), 4 * ui.SCALE()); 
 
 		if (alpha) {
 			var alphaHandle = handle.nest(1, {value: Math.round(calpha * 100) / 100});
 			calpha = ui.slider(alphaHandle, "Alpha", 0.0, 1.0, true);
 			if (alphaHandle.changed) handle.changed = ui.changed = true;
 		}
-		// Mouse picking
+		// Mouse picking for color wheel
 		var gx = ox + ui._windowX;
 		var gy = oy + ui._windowY;
 		if (ui.inputStarted && ui.getInputInRect(gx - cwh, gy - cwh, cw, cw)) wheelSelectedHande = handle;
@@ -198,6 +212,13 @@ class Ext {
 			if (angle < 0) angle = Math.PI + (Math.PI - Math.abs(angle));
 			angle = Math.PI * 2 - angle;
 			chue = angle / (Math.PI * 2);
+			handle.changed = ui.changed = true;
+		}
+		// Mouse picking for cval
+		if (ui.inputStarted && ui.getInputInRect(gradTx + ui._windowX, gradTy + ui._windowY, gradW, gradH)) gradientSelectedHandle = handle;
+		if (ui.inputReleased) gradientSelectedHandle = null;
+		if (ui.inputDown && gradientSelectedHandle == handle) {
+			cval = Math.max(0.01,Math.min(1,1 - (ui.inputY-gradTy - ui._windowY) / gradH));
 			handle.changed = ui.changed = true;
 		}
 		// Save as rgb

--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -145,7 +145,7 @@ class Ext {
 		return handle.position;
 	}
 
-	static var wheelSelectedHande: Handle = null;
+	static var wheelSelectedHandle: Handle = null;
 	static var gradientSelectedHandle: Handle = null;
 	public static function colorWheel(ui: Zui, handle: Handle, alpha = false, w: Null<Float> = null, h: Null<Float> = null, colorPreview = true): kha.Color {
 		if (w == null) w = ui._w;
@@ -204,9 +204,9 @@ class Ext {
 		// Mouse picking for color wheel
 		var gx = ox + ui._windowX;
 		var gy = oy + ui._windowY;
-		if (ui.inputStarted && ui.getInputInRect(gx - cwh, gy - cwh, cw, cw)) wheelSelectedHande = handle;
-		if (ui.inputReleased && wheelSelectedHande != null) {wheelSelectedHande = null; handle.changed = ui.changed = true;}
-		if (ui.inputDown && wheelSelectedHande == handle) {
+		if (ui.inputStarted && ui.getInputInRect(gx - cwh, gy - cwh, cw, cw)) wheelSelectedHandle = handle;
+		if (ui.inputReleased && wheelSelectedHandle != null) {wheelSelectedHandle = null; handle.changed = ui.changed = true;}
+		if (ui.inputDown && wheelSelectedHandle == handle) {
 			csat = Math.min(dist(gx, gy, ui.inputX, ui.inputY), cwh) / cwh;
 			var angle = Math.atan2(ui.inputX - gx, ui.inputY - gy);
 			if (angle < 0) angle = Math.PI + (Math.PI - Math.abs(angle));

--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -205,7 +205,7 @@ class Ext {
 		var gx = ox + ui._windowX;
 		var gy = oy + ui._windowY;
 		if (ui.inputStarted && ui.getInputInRect(gx - cwh, gy - cwh, cw, cw)) wheelSelectedHande = handle;
-		if (ui.inputReleased) wheelSelectedHande = null;
+		if (ui.inputReleased && wheelSelectedHande != null) {wheelSelectedHande = null; handle.changed = ui.changed = true;}
 		if (ui.inputDown && wheelSelectedHande == handle) {
 			csat = Math.min(dist(gx, gy, ui.inputX, ui.inputY), cwh) / cwh;
 			var angle = Math.atan2(ui.inputX - gx, ui.inputY - gy);
@@ -216,7 +216,7 @@ class Ext {
 		}
 		// Mouse picking for cval
 		if (ui.inputStarted && ui.getInputInRect(gradTx + ui._windowX, gradTy + ui._windowY, gradW, gradH)) gradientSelectedHandle = handle;
-		if (ui.inputReleased) gradientSelectedHandle = null;
+		if (ui.inputReleased && gradientSelectedHandle != null) {gradientSelectedHandle = null; handle.changed = ui.changed = true;}
 		if (ui.inputDown && gradientSelectedHandle == handle) {
 			cval = Math.max(0.01,Math.min(1,1 - (ui.inputY-gradTy - ui._windowY) / gradH));
 			handle.changed = ui.changed = true;

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -16,7 +16,8 @@ typedef ZuiOptions = {
 	?khaWindowId: Int,
 	?scaleFactor: Float,
 	?autoNotifyInput: Bool,
-	?color_wheel: kha.Image
+	?color_wheel: kha.Image,
+	?black_white_gradient: kha.Image,
 }
 
 class Zui {


### PR DESCRIPTION
@[paolohuesp](https://github.com/paolohuesp) proposed in https://github.com/armory3d/armorpaint/issues/1106#issuecomment-907729666 to implement a value slider to lighten/darken colors just like it is done in Blender. This PR implements this request.
![grafik](https://user-images.githubusercontent.com/28649121/155848936-24c79456-7603-4002-af06-8da8fff5907c.png)

How is it implemented?

1. I added a new image called black_white_gradient.png. I could have painted the gradient using a four vertex rectangle and two vertex colors but Graphics2 does not support that and the API is not designed to have an additional second color. None the less it would be easy implement it that way. I couldn't add the slider to the existing image because the tint should not change the slider's greyscale. Thus adding an image texture seemed to be a suitable alternative. I could easily add a border, too, which was nice. The size of the newly added image matches the color_wheel image size in order to draw both at the same position. While it might be more efficient to draw them side by side I took the easier way which circumvented changing the existing picking logic because everything is based on the assumption that the image containging the wheel is a big as the whole picker is. If you dislike it feel to tell me. We can also adapt the slider's width or border if you like to. Feel free to comment on the appearance and I will try to change it accordingly.
2. The slider is implemented just like the color wheel except that it is simpler.
3. I set 0.01 as the slider's minimum because 0.0 makes the user loose the H and S values. I think we can savely change it to 0.0 if @[ncuxonaT](https://github.com/ncuxonaT) proposal in https://github.com/armory3d/armorpaint/issues/1245 is fixed. I will try to fix it the next days by setting the RGB value if the user started picking, save the corresponding HSV values in the handle and work on them while picking. The RGB values can be updated during picking to not break the realtime preview for RGB node but as the RGB value is never read again while picking the issue should be gone.

If you accept my PR this is one of the last steps to close https://github.com/armory3d/armorpaint/issues/1106 Essentially only the picker button is still missing. My idea would be to have a button to set the currently selected color picker color. I consider this to be very useful. Now there are two ways to implement it.
1. Add it via the context meu of RGB-node. While it is easy enough to implement, only the RGB node benefits from it.
2. Add it to the colorWheel is complicated because ZUI is a seperate library. One idea would be to add a pointer to a function as a parameter to the picker. If the parameter is null, no button is there. If it is not, the button is shown and the function is called if the button is pressed. The function has to return a color which is set in the picker afterwards. It would also be necessary to add the picker icon from ArmorPaint in order to have a small button.

How should I do it?
