### PR TITLE
Paste nodes at mouse position and make them dragable

### DIFF
--- a/Sources/zui/Nodes.hx
+++ b/Sources/zui/Nodes.hx
@@ -493,6 +493,8 @@ class Nodes {
 					l.id = getLinkId(canvas.links);
 					canvas.links.push(l);
 				}
+				var offsetX = Std.int((Std.int(ui.inputX / ui.SCALE())*SCALE() - wx - PAN_X()) / SCALE()) - pasteCanvas.nodes[pasteCanvas.nodes.length-1].x;
+				var offsetY = Std.int((Std.int(ui.inputY / ui.SCALE())*SCALE() - wy - PAN_Y()) / SCALE()) - pasteCanvas.nodes[pasteCanvas.nodes.length-1].y;
 				for (n in pasteCanvas.nodes) {
 					// Assign unique node id
 					var old_id = n.id;
@@ -509,10 +511,11 @@ class Nodes {
 						if (l.from_id == old_id) l.from_id = n.id;
 						else if (l.to_id == old_id) l.to_id = n.id;
 					}
-					n.x += 10;
-					n.y += 10;
+					n.x += offsetX;
+					n.y += offsetY;
 					canvas.nodes.push(n);
 				}
+				nodesDrag = true;
 				nodesSelected = pasteCanvas.nodes;
 				ui.changed = true;
 			}


### PR DESCRIPTION
ArmorPaint behaves a bit differently from Blender for duplicating nodes. In contrast to Blender ArmorPaint does not allow to move the node around after duplicating. Imho Blender's behavior is better. Therefore I changed it that the nodes can be moved.
How did I do it and how does it affect ArmorPaint's behavior?

- I use the upper left corner of last element in `pasteCanvas.nodes` as pivot point that is directly below the mouse cursor. Why? Suppose the user selects nodes one by one then it is the last one and probably the one where the context menu is opened. This was the most intuitive way imho. A slight improvement might be to always use the one where the context menu was opened but in case ctrl+c is used this does not work anyway. I use the left upper corner because this avoids clicking somewhere on the node while releasing the mouse (suppose the user clicks on a rgb color wheel then the color is changed which is not desired)
- If the user duplicates one or more nodes they can be dragged by mouse. This is good because the user always wants to put them at a meaningful position and shifting them by 10 is never such a position.
- If the user pastes nodes. It is also handy to be able to move them. This is not the case in Blender but Blender puts them exactly over the old ones. That's a stupid behavior anyway.

And finally I think there is a bug in the copy-paste mechanism. Sometimes ctrl+c, ctrl+v does not work and has to be done twice.