### PR TITLE
Search bar for combo boxes

### DIFF
--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -160,6 +160,7 @@ class Zui {
 	var comboSearchBar = false;
 	var submitComboHandle: Handle = null;
 	var comboToSubmit = 0;
+	var comboInitialValue = 0;
 	var tooltipText = "";
 	var tooltipImg: kha.Image = null;
 	var tooltipImgMaxWidth: Null<Int> = null;
@@ -1082,9 +1083,15 @@ class Zui {
 				if (comboSelectedW > _w * 2) comboSelectedW = Std.int(_w * 2);
 				if (comboSelectedW > _w) comboSelectedW += Std.int(TEXT_OFFSET());
 				comboToSubmit = handle.position;
+				comboInitialValue = handle.position;
 			}
 		}
-		if (handle == submitComboHandle) {
+		if (handle == comboSelectedHandle && (isEscapeDown || inputReleasedR)) {
+			handle.position = comboInitialValue;
+			handle.changed = changed = true;
+			submitComboHandle = null;
+		}
+		else if (handle == submitComboHandle) {
 			handle.position = comboToSubmit;
 			submitComboHandle = null;
 			handle.changed = changed = true;
@@ -1411,7 +1418,7 @@ class Zui {
 			}
 		}
 
-		if ((inputReleased || isEscapeDown || isReturnDown) && !comboFirst) {
+		if ((inputReleased || inputReleasedR || isEscapeDown || isReturnDown) && !comboFirst) {
 			comboSelectedHandle = null;
 			comboFirst = true;
 			comboSearchLast = "";

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -1414,6 +1414,7 @@ class Zui {
 		if ((inputReleased || isEscapeDown || isReturnDown) && !comboFirst) {
 			comboSelectedHandle = null;
 			comboFirst = true;
+			comboSearchLast = "";
 		}
 		else comboFirst = false;
 		inputEnabled = comboSelectedHandle == null;

--- a/Sources/zui/Zui.hx
+++ b/Sources/zui/Zui.hx
@@ -1058,7 +1058,7 @@ class Zui {
 		return handle.position == position;
 	}
 
-	public function combo(handle: Handle, texts: Array<String>, label = "", showLabel = false, align = Align.Left, searchBar = false): Int {
+	public function combo(handle: Handle, texts: Array<String>, label = "", showLabel = false, align = Align.Left, searchBar = true): Int {
 		if (!isVisible(ELEMENT_H())) {
 			endElement();
 			return handle.position;


### PR DESCRIPTION
Implemented a search bar for combo boxes
How does it look like?
![grafik](https://user-images.githubusercontent.com/28649121/162920282-3ad9942b-aa0d-4231-b628-e26d3403a756.png)
Does the appearance fit your taste? For example we could change the background if you wish.
What's the purpose?
I'd like to add the search bar at many many places.
- Image node will become way more convenient if able to type the file name. 
- For Blending modes 
![grafik](https://user-images.githubusercontent.com/28649121/162921195-265ca3bb-b97c-4311-ba9f-dc64856fb974.png)
- For selecting an object or to set a filter
- Maybe to replace the current node search?
- Basically it is useful in almost every combobox and is compatible with locales.
- It is the first step for a proper image/material/... selector for image node and other cases.

QUESTION: Currently it is `combo`'s the last parameter. Imho it is a very useful feature and it might be a good idea to set it as the third parameter if it will be used for most comboboxes. Didn't do it to not break the api though... We could also keep it as last parameter and set it to true. then all combo boxes would have a search bar. Might be convenient, too, because even in combo boxes containing few elements searching is useful because it can be done by keyboard.
QUESTION: In case we don't enable it everywhere: Should I extend Nodes.hx to support a parameter for enabling/disabling the search bar in enums or should I enable it in any case?