### PR TITLE
Right align line numbers

### DIFF
--- a/Sources/zui/Ext.hx
+++ b/Sources/zui/Ext.hx
@@ -290,6 +290,14 @@ class Ext {
 		return handle.color;
 	}
 
+	private static function rightAlignNumber(number: Int, length: Int) {
+		var s = number + "";
+		while (s.length < length)
+			s = " " + s;
+
+		return s;
+	}
+
 	public static var textAreaLineNumbers = false;
 	public static var textAreaScrollPastEnd = false;
 	public static var textAreaColoring: TTextColoring = null;
@@ -340,8 +348,9 @@ class Ext {
 			var _y = ui._y;
 			var _TEXT_COL = ui.t.TEXT_COL;
 			ui.t.TEXT_COL = ui.t.ACCENT_COL;
+			var maxLength = Math.ceil(Math.log(lines.length+0.5) / Math.log(10)); // Express log_10 with natural log.
 			for (i in 0...lines.length) {
-				ui.text((i + 1) + "");
+				ui.text(rightAlignNumber(i+1, maxLength));
 				ui._y -= ui.ELEMENT_OFFSET();
 			}
 			ui.t.TEXT_COL = _TEXT_COL;


### PR DESCRIPTION
It's way more beautiful and consistent with all other editors like this:
![grafik](https://user-images.githubusercontent.com/28649121/216781169-87442ef4-4ae0-45d5-81da-b29370fc664e.png)
![grafik](https://user-images.githubusercontent.com/28649121/216781195-dd99b86d-a40e-4972-abc5-09d5c33e6712.png)

Limitation: only for mono space fonts.
